### PR TITLE
Get user email when it is set as private on Github

### DIFF
--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -18,6 +18,29 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
     avatar_url: "https://avatars3.githubusercontent.com/u/10835816"
   }
 
+  @body_email_nil %{
+    access_token: "12345",
+    login: "test_user",
+    name: "Testy McTestface",
+    email: nil,
+    avatar_url: "https://avatars3.githubusercontent.com/u/10835816"
+  }
+
+  @emails [
+    %{
+      "email" => "octocat@github.com",
+      "verified" => true,
+      "primary" => false,
+      "visibility" => "private"
+    },
+    %{
+      "email" => "private_email@gmail.com",
+      "verified" => true,
+      "primary" => true,
+      "visibility" => "private"
+    }
+  ]
+
   def get!(url, headers \\ [], options \\ [])
 
   def get!(
@@ -29,6 +52,29 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
         _options
       ) do
     %{body: "{\"error\": \"test error\"}"}
+  end
+
+  def get!(
+        "https://api.github.com/user",
+        [
+          {"User-Agent", "ElixirAuthGithub"},
+          {"Authorization", "token 42"}
+        ],
+        _options
+      ) do
+    %{body: Poison.encode!(@body_email_nil)}
+  end
+
+  # user emails
+  def get!(
+        "https://api.github.com/user/emails",
+        [
+          {"User-Agent", "ElixirAuthGithub"},
+          {"Authorization", "token 42"}
+        ],
+        _options
+      ) do
+    %{body: Poison.encode!(@emails)}
   end
 
   def get!(_url, _headers, _options) do
@@ -56,6 +102,15 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
         _options
       ) do
     %{body: "access_token=123"}
+  end
+
+  def post!(
+        "https://github.com/login/oauth/access_token?client_id=TEST_ID&client_secret=TEST_SECRET&code=42",
+        _body,
+        _headers,
+        _options
+      ) do
+    %{body: "access_token=42"}
   end
 
   # for some reason GitHub's Post returns a URI encoded string

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirAuthGithub.Mixfile do
   def project do
     [
       app: :elixir_auth_github,
-      version: "1.3.0",
+      version: "1.4.0",
       elixir: "~> 1.10",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/test/elixir_auth_github_test.exs
+++ b/test/elixir_auth_github_test.exs
@@ -67,4 +67,10 @@ defmodule ElixirAuthGithubTest do
     res = ElixirAuthGithub.github_auth("123")
     assert res == {:error, %{"error" => "test error"}}
   end
+
+  test "fetch primary email for user" do
+    setup_test_environment_variables()
+    {:ok, res} = ElixirAuthGithub.github_auth("42")
+    assert res.email == "private_email@gmail.com"
+  end
 end

--- a/test/elixir_auth_github_test.exs
+++ b/test/elixir_auth_github_test.exs
@@ -52,7 +52,6 @@ defmodule ElixirAuthGithubTest do
   test "github_auth returns a user and token" do
     setup_test_environment_variables()
     {:ok, res} = ElixirAuthGithub.github_auth("12345")
-    # IO.inspect(res, label: "res")
     assert res.login == "test_user"
   end
 


### PR DESCRIPTION
ref: #46
Get the primary email linked to the user's Github account.
The `/user` Github endpoint doesn't provide the user's email if this one is private.
We need to send a second request `/user/emails` to get the list of emails, we then select the primary email from this list.