### PR TITLE
Update Hits badge URL to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ to your Elixir/Phoenix Apps.
 [![codecov.io](https://img.shields.io/codecov/c/github/dwyl/elixir-auth-github/master.svg?style=flat-square)](http://codecov.io/github/dwyl/elixir-auth-github?branch=master)
 [![Hex.pm](https://img.shields.io/hexpm/v/elixir_auth_github?color=brightgreen&style=flat-square)](https://hex.pm/packages/elixir_auth_github)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/elixir-auth-github/issues)
-[![HitCount](http://hits.dwyl.io/dwyl/elixir-auth-github.svg)](http://hits.dwyl.io/dwyl/elixir-auth-github)
+[![HitCount](http://hits.dwyl.com/dwyl/elixir-auth-github.svg)](http://hits.dwyl.com/dwyl/elixir-auth-github)
 
 </div>
 


### PR DESCRIPTION
Quick update to Hits URL to fix broken badge. 
![image](https://user-images.githubusercontent.com/194400/141353954-34928e77-c268-4b22-a833-f9e7c1142a8e.png)
