### PR TITLE
PR: Update link to demo app from Heroku to Fly.io issue #68

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: mix
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "07:00"
+    timezone: Europe/London

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
-        otp-version: '24.0.2' # Define the OTP version [required]
+        elixir-version: '1.14.1' # Define the elixir version [required]
+        otp-version: '24.3.4' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ by following these 5 simple steps:
 
 > If you get stuck setting up your App,
 > checkout our working demo:
-> https://github.com/dwyl/elixir-auth-github-demo <br />
-> The demo is deployed on Heroku:
-> https://elixir-auth-github-demo.herokuapp.com/
+> [dwyl/elixir-auth-github-demo](https://github.com/dwyl/elixir-auth-github-demo) <br />
+> The demo is deployed on Fly.io:
+> https://elixir-auth-github-demo.fly.dev
 
 ## 1. Add the hex package to `deps` 📦
 
@@ -69,7 +69,7 @@ Add a line for **`:elixir_auth_github`** in the **`deps`** list:
 ```elixir
 def deps do
   [
-    {:elixir_auth_github, "~> 1.6.1"}
+    {:elixir_auth_github, "~> 1.6"}
   ]
 end
 ```
@@ -114,7 +114,6 @@ GITHUB_CLIENT_SECRET=8eeb143935d1a505692aaef856db9b4da8245f3c
 > file to manage our environment variables on our `localhost`
 > and then use whichever system for environment variables appropriate
 > for our deployment.
-> e.g: [Heroku](https://github.com/dwyl/learn-environment-variables#environment-variables-on-heroku)
 > For an example `.env` file with the environment variables
 > required by `elixir-auth-github` see:
 > [`.env_sample`](https://github.com/dwyl/elixir-auth-github/blob/master/.env_sample)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,9 @@
 import Config
 
+config :elixir_auth_github,
+  httpoison_mock: false
+
+
 if Mix.env() == :test do
   import_config "test.exs"
 end

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule ElixirAuthGithub.Mixfile do
     [
       files: ~w(lib LICENSE mix.exs README.md .formatter.exs config),
       links: %{"GitHub" => "https://github.com/dwyl/elixir-auth-github"},
-      licenses: ["GNU GPL v2.0"],
+      licenses: ["GPL-2.0-or-later"],
       maintainers: ["dwyl & friends! (contributions always welcome)"]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirAuthGithub.Mixfile do
   def project do
     [
       app: :elixir_auth_github,
-      version: "1.6.2",
+      version: "1.6.3",
       elixir: "~> 1.12",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
@@ -57,7 +57,7 @@ defmodule ElixirAuthGithub.Mixfile do
 
   defp package() do
     [
-      files: ~w(lib LICENSE mix.exs README.md .formatter.exs),
+      files: ~w(lib LICENSE mix.exs README.md .formatter.exs config),
       links: %{"GitHub" => "https://github.com/dwyl/elixir-auth-github"},
       licenses: ["GNU GPL v2.0"],
       maintainers: ["dwyl & friends! (contributions always welcome)"]


### PR DESCRIPTION
Deployed to fly.io via https://github.com/dwyl/elixir-auth-github-demo/issues/22 
This PR just updates the link and exports the `/config` for testing convenience. #68 