### PR TITLE
Add scope to auth return

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ is the following format:
   id: 194400,
   following: 173,
   login: "nelsonic",
-  collaborators: 8
+  collaborators: 8,
+  scope: "repo,user:email"
 }
 ```
 

--- a/lib/elixir_auth_github.ex
+++ b/lib/elixir_auth_github.ex
@@ -49,8 +49,8 @@ defmodule ElixirAuthGithub do
   """
   def login_url(%{scopes: scopes, state: state}) do
     login_url() <>
-      "&scope=#{Enum.join(scopes, "%20")}" <>
-      "&state=#{state}"
+    "&scope=#{Enum.join(scopes, "%20")}" <>
+    "&state=#{state}"
   end
 
   def login_url(%{scopes: scopes}) do
@@ -82,9 +82,11 @@ defmodule ElixirAuthGithub do
     |> check_authenticated
   end
 
-  defp check_authenticated(%{"access_token" => access_token}) do
+  defp check_authenticated(%{"access_token" => access_token, "scope" => scope}) do
     access_token
     |> get_user_details
+    |> Map.put(:scope, scope)
+    |> then(&{:ok, &1})
   end
 
   defp check_authenticated(error), do: {:error, error}
@@ -126,8 +128,7 @@ defmodule ElixirAuthGithub do
 
     # transform map with keys as strings into keys as atoms!
     # https://stackoverflow.com/questions/31990134
-    atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
-    {:ok, atom_key_map}
+    _atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
   end
 
   defp set_user_details(error, _token), do: {:error, error}

--- a/lib/elixir_auth_github.ex
+++ b/lib/elixir_auth_github.ex
@@ -49,8 +49,8 @@ defmodule ElixirAuthGithub do
   """
   def login_url(%{scopes: scopes, state: state}) do
     login_url() <>
-    "&scope=#{Enum.join(scopes, "%20")}" <>
-    "&state=#{state}"
+      "&scope=#{Enum.join(scopes, "%20")}" <>
+      "&state=#{state}"
   end
 
   def login_url(%{scopes: scopes}) do
@@ -82,11 +82,9 @@ defmodule ElixirAuthGithub do
     |> check_authenticated
   end
 
-  defp check_authenticated(%{"access_token" => access_token, "scope" => scope}) do
+  defp check_authenticated(%{"access_token" => access_token}) do
     access_token
     |> get_user_details
-    |> Map.put(:scope, scope)
-    |> then(&{:ok, &1})
   end
 
   defp check_authenticated(error), do: {:error, error}
@@ -128,7 +126,8 @@ defmodule ElixirAuthGithub do
 
     # transform map with keys as strings into keys as atoms!
     # https://stackoverflow.com/questions/31990134
-    _atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
+    atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
+    {:ok, atom_key_map}
   end
 
   defp set_user_details(error, _token), do: {:error, error}

--- a/lib/elixir_auth_github.ex
+++ b/lib/elixir_auth_github.ex
@@ -82,9 +82,11 @@ defmodule ElixirAuthGithub do
     |> check_authenticated
   end
 
-  defp check_authenticated(%{"access_token" => access_token}) do
+  defp check_authenticated(%{"access_token" => access_token, "scope" => scope}) do
     access_token
     |> get_user_details
+    |> Map.put(:scope, scope)
+    |> then(&{:ok, &1})
   end
 
   defp check_authenticated(error), do: {:error, error}
@@ -126,8 +128,7 @@ defmodule ElixirAuthGithub do
 
     # transform map with keys as strings into keys as atoms!
     # https://stackoverflow.com/questions/31990134
-    atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
-    {:ok, atom_key_map}
+    _atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
   end
 
   defp set_user_details(error, _token), do: {:error, error}

--- a/lib/elixir_auth_github.ex
+++ b/lib/elixir_auth_github.ex
@@ -85,11 +85,18 @@ defmodule ElixirAuthGithub do
   defp check_authenticated(%{"access_token" => access_token, "scope" => scope}) do
     access_token
     |> get_user_details
+    |> set_scope(scope)
+  end
+
+  defp check_authenticated(error), do: {:error, error}
+
+  defp set_scope({:ok, user_details}, scope) do
+    user_details
     |> Map.put(:scope, scope)
     |> then(&{:ok, &1})
   end
 
-  defp check_authenticated(error), do: {:error, error}
+  defp set_scope({:error, error}, _scope), do: {:error, error}
 
   defp get_user_details(access_token) do
     inject_poison().get!("https://api.github.com/user", [
@@ -128,7 +135,8 @@ defmodule ElixirAuthGithub do
 
     # transform map with keys as strings into keys as atoms!
     # https://stackoverflow.com/questions/31990134
-    _atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
+    atom_key_map = for {key, val} <- user, into: %{}, do: {String.to_atom(key), val}
+    {:ok, atom_key_map}
   end
 
   defp set_user_details(error, _token), do: {:error, error}

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -123,9 +123,4 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
       ) do
     %{body: "access_token=12345&scope=user"}
   end
-
-  # for some reason GitHub's Post returns a URI encoded string
-  def post!(_url, _body, _headers, _options) do
-    %{body: URI.encode_query(@valid_body)}
-  end
 end

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -103,7 +103,7 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
         _headers,
         _options
       ) do
-    %{body: "access_token=123"}
+    %{body: "access_token=123&scope=user"}
   end
 
   def post!(
@@ -112,7 +112,16 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
         _headers,
         _options
       ) do
-    %{body: "access_token=42"}
+    %{body: "access_token=42&scope=user"}
+  end
+
+  def post!(
+        "https://github.com/login/oauth/access_token?client_id=TEST_ID&client_secret=TEST_SECRET&code=12345",
+        _body,
+        _headers,
+        _options
+      ) do
+    %{body: "access_token=12345&scope=user"}
   end
 
   # for some reason GitHub's Post returns a URI encoded string

--- a/test/elixir_auth_github_test.exs
+++ b/test/elixir_auth_github_test.exs
@@ -53,6 +53,13 @@ defmodule ElixirAuthGithubTest do
     assert res.id == "19"
   end
 
+  test "github_auth returns scope string" do
+    setup_test_environment_variables()
+    {:ok, res} = ElixirAuthGithub.github_auth("12345")
+    assert res.scope == "user"
+    assert res.id == "19"
+  end
+
   test "github_auth returns an error with a bad code" do
     setup_test_environment_variables()
     assert ElixirAuthGithub.github_auth("1234") ==

--- a/test/elixir_auth_github_test.exs
+++ b/test/elixir_auth_github_test.exs
@@ -57,7 +57,6 @@ defmodule ElixirAuthGithubTest do
     setup_test_environment_variables()
     {:ok, res} = ElixirAuthGithub.github_auth("12345")
     assert res.scope == "user"
-    assert res.id == "19"
   end
 
   test "github_auth returns an error with a bad code" do


### PR DESCRIPTION
Adds `scope` key to the `ElixirAuthGithub.github_auth` return object