### PR TITLE
Catch-all `HTTPoisonMock.post!`

### DIFF
--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -123,4 +123,8 @@ defmodule ElixirAuthGithub.HTTPoisonMock do
       ) do
     %{body: "access_token=12345&scope=user"}
   end
+
+  def post!(_url, _body, _headers, _options) do
+    %{body: "access_token=123456&scope=user"}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirAuthGithub.Mixfile do
   def project do
     [
       app: :elixir_auth_github,
-      version: "1.6.4",
+      version: "1.6.5",
       elixir: "~> 1.12",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/test/elixir_auth_github_test.exs
+++ b/test/elixir_auth_github_test.exs
@@ -59,6 +59,12 @@ defmodule ElixirAuthGithubTest do
     assert res.scope == "user"
   end
 
+  test "catch-all mock HTTP.post! returns scope string" do
+    setup_test_environment_variables()
+    {:ok, res} = ElixirAuthGithub.github_auth("123456")
+    assert res.scope == "user"
+  end
+
   test "github_auth returns an error with a bad code" do
     setup_test_environment_variables()
     assert ElixirAuthGithub.github_auth("1234") ==


### PR DESCRIPTION
As outlined in https://github.com/dwyl/elixir-auth-github-demo/issues/29 the tests in the demo app fail because `HTTPoisonMock` is no longer matching the `URL` ... 🙄 
This PR ads a catch-all that ensures the _Mocked_ test passes 
so the build passes and I don't have to see it fail every time there's a @dependabot update. 